### PR TITLE
fix ws2_32 library name for case-sensitive

### DIFF
--- a/app/rtkconv_qt/rtkconv_qt.pro
+++ b/app/rtkconv_qt/rtkconv_qt.pro
@@ -28,7 +28,7 @@ win32 {
         RTKLIB =../../src/release/libRTKLib.a
     }
 
-    LIBS+= $${RTKLIB} -lWs2_32 -lwinmm
+    LIBS+= $${RTKLIB} -lws2_32 -lwinmm
 }
 PRE_TARGETDEPS = $${RTKLIB}
 SOURCES += \ 

--- a/app/rtkget_qt/rtkget_qt.pro
+++ b/app/rtkget_qt/rtkget_qt.pro
@@ -23,7 +23,7 @@ win32 {
         RTKLIB =../../src/release/libRTKLib.a
     }
 
-    LIBS+= $${RTKLIB} -lWs2_32 -lwinmm
+    LIBS+= $${RTKLIB} -lws2_32 -lwinmm
 }
 
 PRE_TARGETDEPS = $${RTKLIB}

--- a/app/rtknavi_qt/rtknavi_qt.pro
+++ b/app/rtknavi_qt/rtknavi_qt.pro
@@ -34,7 +34,7 @@ win32 {
         RTKLIB =../../src/release/libRTKLib.a
     }
 
-    LIBS+= $${RTKLIB} -lWs2_32 -lwinmm
+    LIBS+= $${RTKLIB} -lws2_32 -lwinmm
 }
 
 PRE_TARGETDEPS = $${RTKLIB}

--- a/app/rtkplot_qt/rtkplot_qt.pro
+++ b/app/rtkplot_qt/rtkplot_qt.pro
@@ -43,7 +43,7 @@ win32 {
         RTKLIB =../../src/release/libRTKLib.a
     }
 
-    LIBS+= $${RTKLIB} -lWs2_32 -lwinmm
+    LIBS+= $${RTKLIB} -lws2_32 -lwinmm
 }
 
 PRE_TARGETDEPS = $${RTKLIB}

--- a/app/rtkpost_qt/rtkpost_qt.pro
+++ b/app/rtkpost_qt/rtkpost_qt.pro
@@ -29,7 +29,7 @@ win32 {
         RTKLIB =../../src/release/libRTKLib.a
     }
 
-    LIBS+= $${RTKLIB} -lWs2_32 -lwinmm
+    LIBS+= $${RTKLIB} -lws2_32 -lwinmm
 }
 
 PRE_TARGETDEPS = $${RTKLIB}

--- a/app/srctblbrows_qt/srctblbrows_qt.pro
+++ b/app/srctblbrows_qt/srctblbrows_qt.pro
@@ -35,7 +35,7 @@ win32 {
         RTKLIB =../../src/release/libRTKLib.a
     }
 
-    LIBS+= $${RTKLIB} -lWs2_32 -lwinmm
+    LIBS+= $${RTKLIB} -lws2_32 -lwinmm
 }
 
 PRE_TARGETDEPS = $${RTKLIB}

--- a/app/strsvr_qt/strsvr_qt.pro
+++ b/app/strsvr_qt/strsvr_qt.pro
@@ -29,7 +29,7 @@ win32 {
         RTKLIB =../../src/release/libRTKLib.a
     }
 
-    LIBS+= $${RTKLIB} -lWs2_32 -lwinmm
+    LIBS+= $${RTKLIB} -lws2_32 -lwinmm
 }
 
 PRE_TARGETDEPS = $${RTKLIB}


### PR DESCRIPTION
change Ws2_32 to ws2_32 for case-sensitive problem that makes link error in cross-compile environment for MinGW (Win32 excutable) by MXE toolchain in linux platform

MXE: https://mxe.cc/