### PR TITLE
fix ws2_32 library name for case-sensitive

### DIFF
--- a/app/app.pri
+++ b/app/app.pri
@@ -11,7 +11,7 @@ IERS_MODEL {
 }
 
 win* {
-    LIBS += -lWs2_32 -lwinmm
+    LIBS += -lws2_32 -lwinmm
 }
 
 QMAKE_RPATHDIR *= $${ROOT_DIRECTORY}/lib


### PR DESCRIPTION
change Ws2_32 to ws2_32 for case-sensitive problem that makes link error in cross-compile environment for MinGW (Win32 excutable) by MXE toolchain in linux platform

MXE: https://mxe.cc/